### PR TITLE
Fix file_client example

### DIFF
--- a/test/unit/file_client.erl
+++ b/test/unit/file_client.erl
@@ -8,14 +8,12 @@
 -import(ubf_client, [rpc/2]).
 
 defaultPort() -> 2000.
-fileNameToGet() -> "ubf.erl".
+fileNameToGet() -> "file_client.erl".
 
 %% Prerequisites:
 %%
-%% 1. The current working directory must be "..", because test() will
-%%    try to access the file fileNameToGet(), which exists in our
-%%    parent directory.  (Or else create a symbolic link with that
-%%    name that points to the file in "..".
+%% 1. The current working directory must be ".", because test() will
+%%    try to access the file fileNameToGet().
 %%
 %% 2. If the UBF server is not listening on "localhost", then your OS
 %%    environment variable "WHERE" must be set to the hostname of the
@@ -30,7 +28,7 @@ fileNameToGet() -> "ubf.erl".
 %%
 %%   erl -pz ../../ebin
 %%
-%%   > ubf_server:start([file_plugin], file_client:defaultPort(), []).
+%%   > ubf_server:start(undefined, [file_plugin], file_client:defaultPort(), []).
 %%   > ok = file_client:test().
 
 test() ->


### PR DESCRIPTION
Fix the comments which were referencing an non-existant API.  I assume
this test was meant to be run from the unit/ dir.  In that case
it should read a file from the "." directory, not "..".
