### PR TITLE
Turn on TCP_NODELAY in Python EBF client to address a performance issue

### DIFF
--- a/priv/python/pyebf.py
+++ b/priv/python/pyebf.py
@@ -21,6 +21,7 @@ class Socket:
         self.SocketError = SocketError()
         try:
             self.sock = socket.socket(socket.AF_INET,socket.SOCK_STREAM)
+            self.sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
         except socket.error, msg:
             raise SocketError, 'Error in Socket Object Creation!!'
 


### PR DESCRIPTION
It seems the combination of Negel algorithm at client side and delayed ack
at server side causes large latencies for sending small packets.

Here is a performance measure:
A single-threaded client calling Hibari's UBF server:

Python EBF (Before)
40.0063650608 time elapsed for 1000 set operations
24.9960224699 op/sec

Python EBF (After)
0.490041017532 time elapsed for 1000 set operations
2040.64550563 op/sec

References:
http://stackoverflow.com/questions/647813/socket-trouble-in-python/647835#647835
http://bytes.com/topic/python/answers/159515-network-performance#post612983
