### PR TITLE
Exit with shutdown when 'EXIT' shutdown is received.

### DIFF
--- a/src/ubf_plugin_handler.erl
+++ b/src/ubf_plugin_handler.erl
@@ -182,6 +182,9 @@ manager_loop(ExitPid, Mod, State) ->
             end;
         {'EXIT', ExitPid, Reason} ->
             exit(Reason);
+        {'EXIT', _Pid, shutdown} ->
+            %% supervisor shutdown request
+            exit(shutdown);
         {'EXIT', Pid, Reason} ->
             case (catch Mod:handlerStop(Pid, Reason, State)) of
                 {'EXIT', OOps} ->


### PR DESCRIPTION
Supervisor shutdown message should cause the handler
loop to exit with the reason shutdown.
