### PR TITLE
Fixes #9 by allowing state variable to be changed by the managerRPC call...

### DIFF
--- a/.edts
+++ b/.edts
@@ -1,0 +1,4 @@
+:name "ubf_dev"
+:node-sname "ubfdev"
+:app-include-dirs '("include")
+:lib-dirs '("deps")

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ ebin/
 erl_crash.dump
 src/contract_lex.erl
 src/contract_yecc.erl
+*.beam

--- a/src/ubf_plugin_handler.erl
+++ b/src/ubf_plugin_handler.erl
@@ -168,17 +168,17 @@ manager_loop(ExitPid, Mod, State) ->
                 {accept, Mod1, ModManagerPid, State1} ->
                     From ! {self(), {accept, Mod1, ModManagerPid}},
                     manager_loop(ExitPid, Mod, State1);
-                {reject, Reason, _State} ->
+                {reject, Reason, State1} ->
                     From ! {self(), {reject, Reason}},
-                    manager_loop(ExitPid, Mod, State)
+                    manager_loop(ExitPid, Mod, State1)
             end;
         {client_has_stopped, Pid} ->
             case (catch Mod:handlerStop(Pid, normal, State)) of
                 {'EXIT', OOps} ->
                     io:format("plug in error:~p~n",[OOps]),
                     manager_loop(ExitPid, Mod, State);
-                State ->
-                    manager_loop(ExitPid, Mod, State)
+                State1 ->
+                    manager_loop(ExitPid, Mod, State1)
             end;
         {'EXIT', ExitPid, Reason} ->
             exit(Reason);
@@ -190,8 +190,8 @@ manager_loop(ExitPid, Mod, State) ->
                 {'EXIT', OOps} ->
                     io:format("plug in error:~p~n",[OOps]),
                     manager_loop(ExitPid, Mod, State);
-                State ->
-                    manager_loop(ExitPid, Mod, State)
+                State1 ->
+                    manager_loop(ExitPid, Mod, State1)
             end;
         {From, {handler_rpc, Q}} ->
             case (catch Mod:managerRpc(Q, State)) of
@@ -199,9 +199,9 @@ manager_loop(ExitPid, Mod, State) ->
                     io:format("plug in error:~p~n",[OOps]),
                     exit(From, bad_ask_manager),
                     manager_loop(ExitPid, Mod, State);
-                {Reply, State} ->
+                {Reply, State1} ->
                     From ! {handler_rpc_reply, Reply},
-                    manager_loop(ExitPid, Mod, State)
+                    manager_loop(ExitPid, Mod, State1)
             end;
         X ->
             io:format("******Dropping (service manager ~p) self=~p ~p~n",

--- a/test/eunit/stateful_plugin.con
+++ b/test/eunit/stateful_plugin.con
@@ -40,7 +40,9 @@
   server_timeout_req03() => server_timeout_res03() & start;
   server_timeout_req04() => server_timeout_res04() & finish;
   server_crash_req05()   => server_crash_res05() & start;
-  server_crash_req06()   => server_crash_res06() & finish.
+  server_crash_req06()   => server_crash_res06() & finish;
+  manager_rpc_req01()    => manager_rpc_res01() & start;
+  manager_rpc_req02()    => manager_rpc_res02() & finish.
 
 +STATE finish
   restart_req()          => restart_res() & start.

--- a/test/eunit/stateful_plugin.erl
+++ b/test/eunit/stateful_plugin.erl
@@ -46,13 +46,15 @@
                            server_timeout_res03,server_timeout_req03,
                            server_breaks_res01,server_breaks_req01,
                            client_timeout_res03,client_timeout_req03,
-                           client_breaks_res01,client_breaks_req01]}).
+                           client_breaks_res01,client_breaks_req01,
+                           manager_rpc_req01,manager_rpc_req02]}).
 -add_types({types_plugin, [restart_res,restart_req,server_crash_res06,
                            server_crash_req06,server_timeout_res04,
                            server_timeout_req04,server_breaks_res02,
                            server_breaks_req02,client_timeout_res04,
                            client_timeout_req04,client_breaks_res02,
-                           client_breaks_req02]}).
+                           client_breaks_req02,manager_rpc_res01,
+                           manager_rpc_res02]}).
 
 
 %% records
@@ -63,6 +65,7 @@
 
 %% managerState
 -record(managerState, {
+          inc=0
          }).
 
 
@@ -95,7 +98,10 @@ managerRestart(Args,ManagerPid) ->
 %% @doc rpc manager
 managerRpc({restartManager,Args},ManagerStateData)
   when is_record(ManagerStateData,managerState) ->
-    managerStart(Args).
+    managerStart(Args);
+managerRpc(change_state, _ManagerStateData) ->
+    {ok, #managerState{inc=1}}.
+
 
 
 %% @spec handlerStart(Args::list(any()), ManagerPid::pid()) ->
@@ -114,6 +120,9 @@ handlerStop(_Pid,_Reason,ManagerStateData)
 %% @spec handlerRpc(StateName::atom(), Event::any(), StateData::term(), ManagerPid::pid()) ->
 %%          {Reply::any(), NextStateName::atom(), NewStateData::term()}
 %% @doc rpc handler
+handlerRpc(StateName,manager_rpc_req01,StateData,ManagerPid) ->
+    ok = ask_manager(ManagerPid, change_state),
+    {manager_rpc_res01,StateName,StateData};
 handlerRpc(StateName,Event,StateData,_ManagerPid) ->
     {handlerRpc(Event),StateName,StateData}.
 

--- a/test/eunit/stateless_plugin_tests.erl
+++ b/test/eunit/stateless_plugin_tests.erl
@@ -86,6 +86,7 @@ all_actual_tests_(Host,Port,Proto,Stateless,State) ->
              %%, ?_test(test_015(#args{host=Host,port=Port(),proto=Proto,stateless=Stateless,state=State}))
              %%, ?_test(test_016(#args{host=Host,port=Port(),proto=Proto,stateless=Stateless,state=State}))
              %%, ?_test(test_017(#args{host=Host,port=Port(),proto=Proto,stateless=Stateless,state=State}))
+             , ?_test(test_019(#args{host=Host,port=Port(),proto=Proto,stateless=Stateless,state=State}))
             ]
     end.
 
@@ -347,6 +348,24 @@ test_018(#args{proto=Proto})
     ok;
 test_018(Args) ->
     test_shutdown_socket(Args,driver,close).
+
+test_019(#args{stateless=Stateless,
+               proto=Proto})
+    when Stateless==true;
+         Proto==lpc ->
+    ok;
+test_019(Args) ->
+    assert_process(Args, 0, 0, 0, 0, 0),
+    {ok,Pid} = client_connect(Args),
+    assert_process(Args, 1, 1, 1, 1, 1),
+    {reply,ok,State} = client_rpc(Pid,keepalive),
+    assert_process(Args, 1, 1, 1, 1, 1),
+    {reply,manager_rpc_res01,State} = client_rpc(Pid,manager_rpc_req01),
+    assert_process(Args, 1, 1, 1, 1, 1),
+    {reply,ok,State} = client_rpc(Pid,keepalive),
+    assert_process(Args, 1, 1, 1, 1, 1),
+    ok = client_stop(Pid),
+    assert_process(Args, 0, 0, 0, 0, 0).
 
 %%%----------------------------------------------------------------------
 %%% Helpers

--- a/test/eunit/types_plugin.con
+++ b/test/eunit/types_plugin.con
@@ -66,6 +66,11 @@ server_crash_res05()    :: server_crash_res05;
 server_crash_req06()    :: server_crash_req06;
 server_crash_res06()    :: server_crash_res06;
 
+manager_rpc_req01()     :: manager_rpc_req01;
+manager_rpc_res01()     :: manager_rpc_res01;
+manager_rpc_req02()     :: manager_rpc_req02;
+manager_rpc_res02()     :: manager_rpc_res02;
+
 not_implemented_req99() :: not_implemented_req99;
 not_implemented_res99() :: not_implemented_res99;
 


### PR DESCRIPTION
updated ubf_plugin_handler.erl to handle state change by managerRPC callbacks. Added simple test to stateful plugin tests. 

.edts file is for a emacs plugin I use. I highly recommend using https://github.com/tjarvstrand/edts if you use emacs.
